### PR TITLE
Add CollegeMath dataset support and async GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Next, run the following command to start:
 python run.py --num_samples 100 --dataset SQA
 ````
 
-Currently, dataset can be ```["SQA", "GSM8k", "ECQA", "Aqua"]``` 
+Currently, dataset can be ```["SQA", "GSM8k", "ECQA", "Aqua", "CollegeMath"]```
 
 # Dataset
 The datasets used in this work are already included in the ```dataset``` folder.

--- a/data_utils.py
+++ b/data_utils.py
@@ -101,4 +101,33 @@ class ECQA:
 
     def get_test_samples(self):
         return self.get_samples(self.test_path)
+
+
+class CollegeMath:
+    """Dataset loader for college_mathematics_test.csv."""
+
+    def __init__(self, data_path):
+        self.test_path = data_path
+
+    def get_samples(self, file_path):
+        samples = []
+        import csv
+        with open(file_path, newline='', encoding='utf-8') as f:
+            reader = csv.reader(f)
+            for index, row in enumerate(reader):
+                question = row[0]
+                options = row[1:-1]
+                answer = row[-1]
+                samples.append({
+                    "index": index,
+                    "question": question,
+                    "options": options,
+                    "answer": answer,
+                    "gold_explanation": ""
+                })
+
+        return samples
+
+    def get_test_samples(self):
+        return self.get_samples(self.test_path)
     

--- a/run.py
+++ b/run.py
@@ -8,7 +8,7 @@ import numpy as np
 from utils import *
 from generation import *
 from tqdm import tqdm
-from data_utils import StrategyQA, GSM8k, Aqua, ECQA
+from data_utils import StrategyQA, GSM8k, Aqua, ECQA, CollegeMath
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -16,6 +16,9 @@ if __name__ == '__main__':
     parser.add_argument('--dataset', default='SQA', type=str)
     parser.add_argument('--num_samples', default=100, type=int)
     parser.add_argument('--round', default=2, type=int)
+    parser.add_argument('--gpt-model', default='gpt-35-turbo', type=str)
+    parser.add_argument('--gpt-base-url', default=None, type=str)
+    parser.add_argument('--workers', default=1, type=int, help='Number of concurrent GPT requests')
     args = parser.parse_args()
 
     if args.dataset == "SQA":
@@ -26,16 +29,23 @@ if __name__ == '__main__':
         data = GSM8k(data_dir=f'./dataset/{args.dataset}')
     elif args.dataset == "Aqua":
         data = Aqua(data_dir=f'./dataset/{args.dataset}')
+    elif args.dataset == "CollegeMath":
+        data = CollegeMath(data_path='./college_mathematics_test.csv')
 
     test_samples = data.get_test_samples()[:args.num_samples]
     print(f"Number of test samples={len(test_samples)}")
 
-    with open(f'convincing/{args.dataset}/chatgpt.json', 'r') as f:
-        convincing_gpt = json.load(f)
-    with open(f'convincing/{args.dataset}/claude.json', 'r') as f:
-        convincing_claude = json.load(f)
-    with open(f'convincing/{args.dataset}/bard.json', 'r') as f:
-        convincing_bard = json.load(f)
+    try:
+        with open(f'convincing/{args.dataset}/chatgpt.json', 'r') as f:
+            convincing_gpt = json.load(f)
+        with open(f'convincing/{args.dataset}/claude.json', 'r') as f:
+            convincing_claude = json.load(f)
+        with open(f'convincing/{args.dataset}/bard.json', 'r') as f:
+            convincing_bard = json.load(f)
+    except FileNotFoundError:
+        convincing_gpt = []
+        convincing_claude = []
+        convincing_bard = []
 
     claude = ClaudeModel()
 
@@ -65,21 +75,24 @@ if __name__ == '__main__':
         break
 
     gpt_result = []
-    for test_sample in tqdm(test_samples[len(gpt_result):]):
-        tmp = {}
-        tmp['gold_answer'] = test_sample['answer']
+    def gpt_task(test_sample):
         try:
             result = gpt_gen_ans(test_sample,
-                                convincing_samples=convincing_claude+convincing_bard,
-                                additional_instruc=None,
-                                intervene=False,
-                                dataset=args.dataset)
+                                 convincing_samples=convincing_claude+convincing_bard,
+                                 additional_instruc=None,
+                                 intervene=False,
+                                 dataset=args.dataset,
+                                 model=args.gpt_model,
+                                 base_url=args.gpt_base_url)
         except InvalidRequestError:
             print("blocked by Azure OpenAI’s content management policy.")
             result = invalid_result(args.dataset)
-        tmp['prediction'] = result
-        gpt_result.append(tmp)
-        time.sleep(1)
+        return {'gold_answer': test_sample['answer'], 'prediction': result}
+
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        for out in tqdm(executor.map(gpt_task, test_samples[len(gpt_result):])):
+            gpt_result.append(out)
    
     bard_result = []
     for test_sample in tqdm(test_samples[len(bard_result):]):
@@ -127,7 +140,10 @@ if __name__ == '__main__':
                             all_results,
                             rounds=r,
                             convincing_samples=convincing_claude+convincing_bard,
-                            dataset=args.dataset)
+                            dataset=args.dataset,
+                            model=args.gpt_model,
+                            base_url=args.gpt_base_url,
+                            workers=args.workers)
 
         all_results = bard_debate(test_samples,
                             all_results,

--- a/utils.py
+++ b/utils.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from collections import Counter
 
 random.seed(1234)
-datasets = ["SQA", "GSM8k", "ECQA", "Aqua"]
+datasets = ["SQA", "GSM8k", "ECQA", "Aqua", "CollegeMath"]
 
 def prepare_context(test_sample, convincing_samples=None, intervene=False, dataset="SQA"):
     assert dataset in datasets


### PR DESCRIPTION
## Summary
- add `CollegeMath` loader for `college_mathematics_test.csv`
- allow GPT model and base URL selection
- enable concurrent GPT requests
- update dataset list
- document new dataset

## Testing
- `python -m py_compile generation.py data_utils.py run.py utils.py claude.py`

------
https://chatgpt.com/codex/tasks/task_e_687cca620f048320a48f3ecb5d7cd3e6